### PR TITLE
added n_components arg

### DIFF
--- a/MulticoreTSNE/run/run_optsne.py
+++ b/MulticoreTSNE/run/run_optsne.py
@@ -12,7 +12,7 @@ default_result_path = "tsne_results.csv"
 parser = argparse.ArgumentParser()
 parser.add_argument("--data", help='Path to data file')
 parser.add_argument("--n_threads", help='Number of threads', default=1, type=int)
-parser.add_argument("--n_components", help='Number of dimensions of the embedded space', default=2, type=int)
+parser.add_argument("--n_components", help='Number of result dimensions in the embedded space', default=2, type=int)
 parser.add_argument("--learning_rate", help='Learning rate', default=-1, type=float)
 parser.add_argument("--n_iter_early_exag", help='Number of iterations out of total to spend in early exaggeration', default=250, type=int)
 parser.add_argument("--n_iter", help='Total number of iterations', default=1000, type=int)

--- a/MulticoreTSNE/run/run_optsne.py
+++ b/MulticoreTSNE/run/run_optsne.py
@@ -12,6 +12,7 @@ default_result_path = "tsne_results.csv"
 parser = argparse.ArgumentParser()
 parser.add_argument("--data", help='Path to data file')
 parser.add_argument("--n_threads", help='Number of threads', default=1, type=int)
+parser.add_argument("--n_components", help='Number of dimensions of the embedded space', default=2, type=int)
 parser.add_argument("--learning_rate", help='Learning rate', default=-1, type=float)
 parser.add_argument("--n_iter_early_exag", help='Number of iterations out of total to spend in early exaggeration', default=250, type=int)
 parser.add_argument("--n_iter", help='Total number of iterations', default=1000, type=int)
@@ -47,6 +48,7 @@ if args.learning_rate == -1:
 
 tsne = TSNE(n_jobs=int(args.n_threads),
             learning_rate=args.learning_rate,
+            n_components = args.n_components,
             n_iter=args.n_iter,
             n_iter_early_exag=args.n_iter_early_exag,
             perplexity=args.perp,

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A script `run_optsne.py` is included that allows this package to be run from the
 Add these flags followed directly by values to run_optsne.py to modify algorithm behavior. E.g., `python2 MulticoreTSNE/run/run_optsne.py --optsne --data bendall20k-data.csv --n_threads 4 --perp 50 --n_obs 5000 --verbose 20`. These flags describe arguments to the command line script only. They generally map to the python package itself but some have slightly different names.
 - `--data` is the filepath to the data CSV file to be run through the algorithm.
 - `--n_threads` is the number of CPU threads to use.
+- `--n_components` is the number of dimensions in which the data is embedded after dimensionality reduction.
 - `--learning_rate` is the learning rate (aka "eta"). This is set automatically of running in opt-SNE mode but can be overridden if given as an argument.
 - `--n_iter_early_exag` is the number of iterations out of total to spend in early exaggeration. If running in opt-SNE mode this argument is ignored.
 - `--n_iter` is the total number of iterations. If running in opt-SNE mode this argument is used to stop the run if opt-SNE has not already done so by this point.


### PR DESCRIPTION
Hello,

A small modification on the original run_optsne.py script for argument parsing. I added n_components as it could be interesting for some usage (in my case for the oneSENSE approach), by default the argument is "2".